### PR TITLE
fix: PagingTable, bottom page number button and input text is not wor…

### DIFF
--- a/src/components/PagingTable/components/Pagination.tsx
+++ b/src/components/PagingTable/components/Pagination.tsx
@@ -63,12 +63,6 @@ export default class ReactTablePagination extends Component<
     this.state = { page: props.page };
   }
 
-  static getDerivedStateFromProps(nextProps) {
-    return {
-      page: nextProps.page,
-    };
-  }
-
   getSafePage = page => {
     const pg = Number.isNaN(page) ? this.props.page : page;
     return Math.min(Math.max(pg, 0), this.props.pages - 1);


### PR DESCRIPTION
…king as expected

1. nextProps in getDerivedStateFromProps lifycycle is overriding the updated state to older values. Hence removed the life cycle method. Without this pagination works properly.